### PR TITLE
PowerManagerService: fix HW button illumination timeout

### DIFF
--- a/services/core/java/com/android/server/power/PowerManagerService.java
+++ b/services/core/java/com/android/server/power/PowerManagerService.java
@@ -227,6 +227,7 @@ public final class PowerManagerService extends SystemService
     private int mKeyboardBrightnessSettingDefault;
 
     private boolean mButtonPressed = false;
+    private boolean mButtonOn = false;
     private boolean mButtonLightOnKeypressOnly;
 
     private final Object mLock = new Object();
@@ -1315,7 +1316,9 @@ public final class PowerManagerService extends SystemService
             } else {
                 if (eventTime > mLastUserActivityTime) {
                     mButtonPressed = event == PowerManager.USER_ACTIVITY_EVENT_BUTTON;
-                    if (mButtonLightOnKeypressOnly && mButtonPressed) {
+                    if ((mButtonLightOnKeypressOnly && mButtonPressed)
+                            || eventTime == mLastWakeTime) {
+                        mButtonPressed = true;
                         mLastButtonActivityTime = eventTime;
                     }
                     mLastUserActivityTime = eventTime;
@@ -1881,14 +1884,21 @@ public final class PowerManagerService extends SystemService
                             if (mButtonTimeout != 0
                                     && now > mLastButtonActivityTime + mButtonTimeout) {
                                 mButtonsLight.setBrightness(0);
+                                mButtonOn = false;
                             } else {
                                 if ((!mButtonLightOnKeypressOnly || mButtonPressed) &&
                                         !mProximityPositive) {
                                     mButtonsLight.setBrightness(buttonBrightness);
                                     mButtonPressed = false;
                                     if (buttonBrightness != 0 && mButtonTimeout != 0) {
-                                        nextTimeout = now + mButtonTimeout;
+                                        mButtonOn = true;
+                                        if (now + mButtonTimeout < nextTimeout) {
+                                            nextTimeout = now + mButtonTimeout;
+                                        }
                                     }
+                                } else if (mButtonLightOnKeypressOnly && mButtonOn &&
+                                        mLastButtonActivityTime + mButtonTimeout < nextTimeout) {
+                                    nextTimeout = mLastButtonActivityTime + mButtonTimeout;
                                 }
                             }
                         }
@@ -1899,6 +1909,7 @@ public final class PowerManagerService extends SystemService
                             if (mWakefulness == WAKEFULNESS_AWAKE) {
                                 mButtonsLight.setBrightness(0);
                                 mKeyboardLight.setBrightness(0);
+                                mButtonOn = false;
                             }
                         }
                     }


### PR DESCRIPTION
Patch 20a3c7c4e823a89e428997a1c2771c0c4f1d4684, introducing hardware
button backlight on button keypress only, also introduced a bug:

When touching a button and then performing display activity while
the buttons are still on, the buttons would keep lightened up until
the next user interaction, potentially only switched off at the next
screen off timeout.  Also, the buttons were not illuminated on
device wakeup.

This patch fixes it, together with another, long-standing problem:

When touching a hardware button, nextTimeout was set to
now + mButtonTimeout, even if mButtonTimeout is longer than the timeout
determined by the screen off timeout.  To wit, if screen timeout is set
to 15 secs, but button timeout to values > 15 secs.

Change-Id: I8a56f1d1e0138c38ed6fe294e4816a9f7f744f1e
Signed-off-by: Corinna Vinschen <xda@vinschen.de>